### PR TITLE
Disable https redirection in development env

### DIFF
--- a/Pomodoro.Api/Program.cs
+++ b/Pomodoro.Api/Program.cs
@@ -72,7 +72,10 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHttpsRedirection();
+}
 
 app.UseCors(pomodoroSpecificOrigins);
 


### PR DESCRIPTION
To use "ng-openapi-gen" in FE project we need to disable redirect to https in development environment, because "ng-openapi-gen" doesn't support self-signed certificates