### PR TITLE
Feature/settings service

### DIFF
--- a/Pomodoro.Api/ActionFilterAttributes/ValidateModelAttribute.cs
+++ b/Pomodoro.Api/ActionFilterAttributes/ValidateModelAttribute.cs
@@ -8,17 +8,22 @@ using Microsoft.AspNetCore.Mvc.Filters;
 namespace Pomodoro.Api.ActionFilterAttributes
 {
     /// <summary>
-    /// Action filter attribute to be used globally on API controllers for model state validation.
+    /// Action filter attribute to be used globally on API controllers for model validation.
     /// </summary>
     public class ValidateModelAttribute : ActionFilterAttribute
     {
         /// <summary>
-        /// Checks that the model state is valid.<br/>
+        /// Checks that the model is not null and its state is valid.<br/>
         /// Called before the action executes, after model binding is complete.
         /// </summary>
         /// <param name="context">The <see cref="ActionExecutingContext"/>.</param>
         public override void OnActionExecuting(ActionExecutingContext context)
         {
+            if (context.ActionArguments.Values.Any(val => val is null))
+            {
+                context.Result = new BadRequestObjectResult("The argument cannot be null.");
+            }
+
             if (!context.ModelState.IsValid)
             {
                 context.Result = new BadRequestObjectResult(context.ModelState);

--- a/Pomodoro.Api/Controllers/SettingsController.cs
+++ b/Pomodoro.Api/Controllers/SettingsController.cs
@@ -1,0 +1,141 @@
+﻿// <copyright file="SettingsController.cs" company="PomodoroGroup_GL_BaseCamp">
+// Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
+// </copyright>
+
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Pomodoro.Api.Controllers.Base;
+using Pomodoro.Api.ViewModels;
+using Pomodoro.Core.Interfaces.IServices;
+using Pomodoro.Core.Models;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Pomodoro.Api.Controllers
+{
+    /// <summary>
+    /// API controller for managing pomodoro settings related to the current user.
+    /// </summary>
+    [Route("api/[controller]")]
+    [ApiController]
+    [Authorize]
+    public class SettingsController : BaseController
+    {
+        private readonly IMapper mapper;
+        private readonly ISettingsService settingsService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SettingsController"/> class.
+        /// </summary>
+        /// <param name="mapper">Interface for mapping 2 objects.</param>
+        /// <param name="settingsService">Service for managing user settings.</param>
+        public SettingsController(IMapper mapper, ISettingsService settingsService)
+        {
+            this.mapper = mapper;
+            this.settingsService = settingsService;
+        }
+
+        /// <summary>
+        /// Gets pomodoro settings related to the current user.
+        /// </summary>
+        /// <returns>A <see cref="SettingsViewModel"/> object.</returns>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [SwaggerResponse(200, "Returns an object containing user settings.")]
+        [SwaggerResponse(401, "An unauthorized request cannot be processed.")]
+        [SwaggerResponse(404, "No settings found for the current user.")]
+        [SwaggerResponse(500, "An unhandled exception occurred on the server while executing the request.")]
+        public async Task<ActionResult<SettingsViewModel>> GetUserSettings()
+        {
+            var settingsModel = await this.settingsService
+                .GetUserSettingsAsync(this.UserId);
+
+            if (settingsModel is null)
+            {
+                return this.NotFound("No settings found for the current user.");
+            }
+
+            var settingsViewModel = this.mapper.Map<SettingsViewModel>(settingsModel);
+            return this.Ok(settingsViewModel);
+        }
+
+        /// <summary>
+        /// Creates pomodoro settings related to the current user.
+        /// </summary>
+        /// <param name="settingsVewModel">Represents object to be created.</param>
+        /// <returns>Created object represented by <see cref="SettingsViewModel"/>.</returns>
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [SwaggerResponse(201, "Returns created object containing user settings.")]
+        [SwaggerResponse(400, "The model state is invalid or there is a mismatch.")]
+        [SwaggerResponse(401, "An unauthorized request cannot be processed.")]
+        [SwaggerResponse(409, "Pomodoro settings for the current user already exist.")]
+        [SwaggerResponse(500, "An unhandled exception occurred on the server while executing the request.")]
+        public async Task<ActionResult<SettingsViewModel>> CreateSettings([FromBody] SettingsViewModel settingsVewModel)
+        {
+            if (this.UserId != settingsVewModel.UserId)
+            {
+                return this.BadRequest("UserId mismatch.");
+            }
+
+            var userSettings = await this.settingsService
+                .GetUserSettingsAsync(this.UserId);
+            if (userSettings != null)
+            {
+                return this.Conflict("Pomodoro settings for the current user already exist.");
+            }
+
+            var settingsModel = this.mapper.Map<SettingsModel>(settingsVewModel);
+            settingsModel = await this.settingsService.CreateSettingsAsync(settingsModel);
+
+            var createdViewModel = this.mapper.Map<SettingsViewModel>(settingsModel);
+            return this.CreatedAtAction(nameof(this.GetUserSettings), createdViewModel);
+        }
+
+        /// <summary>
+        /// Updates pomodoro settings related to the current user.
+        /// </summary>
+        /// <param name="id">Id of the pomodoro settings.</param>
+        /// <param name="settingsViewModel">Represents object to be updated.</param>
+        /// <returns>Updated object represented by <see cref="SettingsViewModel"/>.</returns>
+        [HttpPut("{id}")]
+        [ProducesResponseType(StatusCodes.Status202Accepted)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [SwaggerResponse(202, "Returns updated object containing user settings.")]
+        [SwaggerResponse(400, "The model state is invalid or there is a mismatch.")]
+        [SwaggerResponse(401, "An unauthorized request cannot be processed.")]
+        [SwaggerResponse(404, "No settings found by the provided id.")]
+        [SwaggerResponse(500, "An unhandled exception occurred on the server while executing the request.")]
+        public async Task<ActionResult<SettingsViewModel>> UpdateSettings(
+            Guid id,
+            [FromBody] SettingsViewModel settingsViewModel)
+        {
+            if (id != settingsViewModel.Id)
+            {
+                return this.BadRequest("SettingsId mismatch.");
+            }
+
+            var modelToUpdate = await this.settingsService.GetSettingsAsync(id);
+            if (modelToUpdate is null)
+            {
+                return this.NotFound("No settings found by the provided id.");
+            }
+
+            var model = this.mapper.Map<SettingsModel>(settingsViewModel);
+            model = await this.settingsService.UpdateSettingsAsync(model);
+
+            var updated = this.mapper.Map<SettingsViewModel>(model);
+            return this.AcceptedAtAction(nameof(this.GetUserSettings), updated);
+        }
+    }
+}

--- a/Pomodoro.Api/Controllers/SettingsController.cs
+++ b/Pomodoro.Api/Controllers/SettingsController.cs
@@ -63,7 +63,8 @@ namespace Pomodoro.Api.Controllers
         }
 
         /// <summary>
-        /// Creates pomodoro settings related to the current user.
+        /// Creates pomodoro settings related to the current user.<br/>
+        /// Removes previous settings, if any.
         /// </summary>
         /// <param name="settingsViewModel">Represents object to be created.</param>
         /// <returns>Created object represented by <see cref="SettingsViewModel"/>.</returns>
@@ -72,26 +73,17 @@ namespace Pomodoro.Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [SwaggerResponse(201, "Returns created object containing user settings.")]
         [SwaggerResponse(400, "The model state is invalid.")]
         [SwaggerResponse(401, "An unauthorized request cannot be processed.")]
         [SwaggerResponse(403, "User cannot create settings for another person.")]
-        [SwaggerResponse(409, "Pomodoro settings for the current user already exist.")]
         [SwaggerResponse(500, "An unhandled exception occurred on the server while executing the request.")]
         public async Task<ActionResult<SettingsViewModel>> CreateSettings([FromBody] SettingsViewModel settingsViewModel)
         {
             if (this.UserId != settingsViewModel.UserId)
             {
                 return this.Forbid();
-            }
-
-            var userSettings = await this.settingsService
-                .GetUserSettingsAsync(this.UserId);
-            if (userSettings != null)
-            {
-                return this.Conflict("Pomodoro settings for the current user already exist.");
             }
 
             var settingsModel = this.mapper.Map<SettingsModel>(settingsViewModel);

--- a/Pomodoro.Api/Controllers/SettingsController.cs
+++ b/Pomodoro.Api/Controllers/SettingsController.cs
@@ -126,17 +126,15 @@ namespace Pomodoro.Api.Controllers
                 return this.BadRequest("SettingsId mismatch.");
             }
 
-            var modelToUpdate = await this.settingsService.GetSettingsAsync(id);
-            if (modelToUpdate is null)
+            var settingsModel = this.mapper.Map<SettingsModel>(settingsViewModel);
+            settingsModel = await this.settingsService.UpdateSettingsAsync(settingsModel);
+            if (settingsModel is null)
             {
                 return this.NotFound("No settings found by the provided id.");
             }
 
-            var model = this.mapper.Map<SettingsModel>(settingsViewModel);
-            model = await this.settingsService.UpdateSettingsAsync(model);
-
-            var updated = this.mapper.Map<SettingsViewModel>(model);
-            return this.AcceptedAtAction(nameof(this.GetUserSettings), updated);
+            var updatedViewModel = this.mapper.Map<SettingsViewModel>(settingsModel);
+            return this.AcceptedAtAction(nameof(this.GetUserSettings), updatedViewModel);
         }
     }
 }

--- a/Pomodoro.Api/Mapping/SettingsProfile.cs
+++ b/Pomodoro.Api/Mapping/SettingsProfile.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="SettingsProfile.cs" company="PomodoroGroup_GL_BaseCamp">
+// Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
+// </copyright>
+
+using AutoMapper;
+using Pomodoro.Api.ViewModels;
+using Pomodoro.Core.Models;
+
+namespace Pomodoro.Api.Mapping
+{
+    /// <summary>
+    /// Provides mapping configuration for models which represent pomodoro settings.
+    /// </summary>
+    public class SettingsProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SettingsProfile"/> class.
+        /// </summary>
+        public SettingsProfile()
+        {
+            this.CreateMap<SettingsModel, SettingsViewModel>()
+                .ReverseMap();
+        }
+    }
+}

--- a/Pomodoro.Api/Pomodoro.Api.csproj
+++ b/Pomodoro.Api/Pomodoro.Api.csproj
@@ -36,6 +36,7 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\Pomodoro.Core\Pomodoro.Core.csproj" />
 	  <ProjectReference Include="..\Pomodoro.DataAccess\Pomodoro.DataAccess.csproj" />
+	  <ProjectReference Include="..\Pomodoro.Services\Pomodoro.Services.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Pomodoro.Api/Program.cs
+++ b/Pomodoro.Api/Program.cs
@@ -10,6 +10,7 @@ using Pomodoro.Api.SecurityContext;
 using Pomodoro.Api.Services;
 using Pomodoro.Core.Interfaces.IServices;
 using Pomodoro.DataAccess.Extensions;
+using Pomodoro.Services.Realizations;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.MSSqlServer;
@@ -27,6 +28,8 @@ builder.Services.AddRepositories();
 builder.Services.AddIdentityEF();
 
 builder.Services.AddScoped<AuthService>();
+
+builder.Services.AddScoped<ISettingsService, SettingsService>();
 
 builder.Services.AddJwtAuthentication(builder.Configuration);
 

--- a/Pomodoro.Api/Program.cs
+++ b/Pomodoro.Api/Program.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Reflection;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.OpenApi.Models;
 using Pomodoro.Api.ActionFilterAttributes;
 using Pomodoro.Api.Extensions;
@@ -82,6 +83,30 @@ builder.Services.AddSwaggerGen(option =>
 
     var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
     option.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+
+    // Include 'SecurityScheme' to use JWT Authentication
+    var jwtSecurityScheme = new OpenApiSecurityScheme
+    {
+        Scheme = JwtBearerDefaults.AuthenticationScheme,
+        BearerFormat = "JWT",
+        Name = "JWT Authentication",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.Http,
+        Description = "Put **_ONLY_** your JWT Bearer token on textbox below!",
+
+        Reference = new OpenApiReference
+        {
+            Id = JwtBearerDefaults.AuthenticationScheme,
+            Type = ReferenceType.SecurityScheme,
+        },
+    };
+
+    option.AddSecurityDefinition(jwtSecurityScheme.Reference.Id, jwtSecurityScheme);
+
+    option.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        { jwtSecurityScheme, Array.Empty<string>() },
+    });
 });
 
 builder.Services.AddTransient<ISecurityContextService, SecurityContextService>();

--- a/Pomodoro.Api/ViewModels/Base/BaseUserOrientedViewModel.cs
+++ b/Pomodoro.Api/ViewModels/Base/BaseUserOrientedViewModel.cs
@@ -2,7 +2,7 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
-namespace Pomodoro.Api.ViewModels
+namespace Pomodoro.Api.ViewModels.Base
 {
     /// <summary>
     /// Represents an abstract class to be inherited by view models which include data related to a certain user.

--- a/Pomodoro.Api/ViewModels/Base/BaseViewModel.cs
+++ b/Pomodoro.Api/ViewModels/Base/BaseViewModel.cs
@@ -2,7 +2,7 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
-namespace Pomodoro.Api.ViewModels
+namespace Pomodoro.Api.ViewModels.Base
 {
     /// <summary>
     /// Represents an abstract class to be inherited by view models which hold an id for DB.

--- a/Pomodoro.Api/ViewModels/BaseViewModel.cs
+++ b/Pomodoro.Api/ViewModels/BaseViewModel.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="BaseViewModel.cs" company="PomodoroGroup_GL_BaseCamp">
+// Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
+// </copyright>
+
+namespace Pomodoro.Api.ViewModels
+{
+    /// <summary>
+    /// Represents an abstract class to be inherited by view models which hold an id for DB.
+    /// </summary>
+    public abstract class BaseViewModel
+    {
+        /// <summary>
+        /// Gets or sets the id of the view model.
+        /// </summary>
+        public Guid Id { get; set; }
+    }
+}

--- a/Pomodoro.Api/ViewModels/SettingsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="SettingsViewModel.cs" company="PomodoroGroup_GL_BaseCamp">
+// Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
+// </copyright>
+
+namespace Pomodoro.Api.ViewModels
+{
+    /// <summary>
+    /// Represents a view model which contains user settings.
+    /// </summary>
+    public class SettingsViewModel : BaseViewModel
+    {
+        /// <summary>
+        /// Gets or sets user id.
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Gets or sets duration (in minutes) of the pomodoro timer.
+        /// </summary>
+        public byte PomodoroDuration { get; set; }
+
+        /// <summary>
+        /// Gets or sets duration (in minutes) of the short break between pomodoros.
+        /// </summary>
+        public byte ShortBreak { get; set; }
+
+        /// <summary>
+        /// Gets or sets duration (in minutes) of the long break between pomodoros.
+        /// </summary>
+        public byte LongBreak { get; set; }
+
+        /// <summary>
+        /// Gets or sets number of pomodoros after which the long break starts.
+        /// </summary>
+        public byte PomodorosBeforeLongBreak { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether rounds should start automatically.
+        /// </summary>
+        public bool AutostartEnabled { get; set; }
+    }
+}

--- a/Pomodoro.Api/ViewModels/SettingsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,8 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
+using Pomodoro.Api.ViewModels.Base;
+
 namespace Pomodoro.Api.ViewModels
 {
     /// <summary>

--- a/Pomodoro.Api/ViewModels/SettingsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/SettingsViewModel.cs
@@ -2,6 +2,7 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
+using System.ComponentModel.DataAnnotations;
 using Pomodoro.Api.ViewModels.Base;
 
 namespace Pomodoro.Api.ViewModels
@@ -19,21 +20,25 @@ namespace Pomodoro.Api.ViewModels
         /// <summary>
         /// Gets or sets duration (in minutes) of the pomodoro timer.
         /// </summary>
+        [Range(1, byte.MaxValue, ErrorMessage = "The {0} property must be in the range from {1} to {2}.")]
         public byte PomodoroDuration { get; set; }
 
         /// <summary>
         /// Gets or sets duration (in minutes) of the short break between pomodoros.
         /// </summary>
+        [Range(1, byte.MaxValue, ErrorMessage = "The {0} property must be in the range from {1} to {2}.")]
         public byte ShortBreak { get; set; }
 
         /// <summary>
         /// Gets or sets duration (in minutes) of the long break between pomodoros.
         /// </summary>
+        [Range(1, byte.MaxValue, ErrorMessage = "The {0} property must be in the range from {1} to {2}.")]
         public byte LongBreak { get; set; }
 
         /// <summary>
         /// Gets or sets number of pomodoros after which the long break starts.
         /// </summary>
+        [Range(1, byte.MaxValue, ErrorMessage = "The {0} property must be in the range from {1} to {2}.")]
         public byte PomodorosBeforeLongBreak { get; set; }
 
         /// <summary>

--- a/Pomodoro.Api/ViewModels/Statistics/AnnualStatisticsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/Statistics/AnnualStatisticsViewModel.cs
@@ -2,6 +2,8 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
+using Pomodoro.Api.ViewModels.Base;
+
 namespace Pomodoro.Api.ViewModels.Statistics
 {
     /// <summary>

--- a/Pomodoro.Api/ViewModels/Statistics/DailyStatisticsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/Statistics/DailyStatisticsViewModel.cs
@@ -2,6 +2,8 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
+using Pomodoro.Api.ViewModels.Base;
+
 namespace Pomodoro.Api.ViewModels.Statistics
 {
     /// <summary>

--- a/Pomodoro.Api/ViewModels/Statistics/MonthlyStatisticsViewModel.cs
+++ b/Pomodoro.Api/ViewModels/Statistics/MonthlyStatisticsViewModel.cs
@@ -2,6 +2,7 @@
 // Copyright (c) PomodoroGroup_GL_BaseCamp. All rights reserved.
 // </copyright>
 
+using Pomodoro.Api.ViewModels.Base;
 using Pomodoro.Core.Enums;
 
 namespace Pomodoro.Api.ViewModels.Statistics

--- a/Pomodoro.Core/Interfaces/IRepositories/IBaseRepository.cs
+++ b/Pomodoro.Core/Interfaces/IRepositories/IBaseRepository.cs
@@ -5,6 +5,7 @@ namespace Pomodoro.Core.Interfaces.IRepositories
     public interface IBaseRepository<T> where T : class
     {
         Task<T?> GetByIdAsync(Guid id);
+        Task<bool> HasByIdAsync(Guid id);
         Task<IEnumerable<T>> GetAllAsync();
         Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
         Task AddAsync(T entity);

--- a/Pomodoro.Core/Interfaces/IServices/ISettingsService.cs
+++ b/Pomodoro.Core/Interfaces/IServices/ISettingsService.cs
@@ -7,6 +7,6 @@ namespace Pomodoro.Core.Interfaces.IServices
         Task<SettingsModel?> GetSettingsAsync(Guid id);
         Task<SettingsModel?> GetUserSettingsAsync(Guid userId);
         Task<SettingsModel> CreateSettingsAsync(SettingsModel settingsModel);
-        Task<SettingsModel> UpdateSettingsAsync(SettingsModel settingsModel);
+        Task<SettingsModel?> UpdateSettingsAsync(SettingsModel settingsModel);
     }
 }

--- a/Pomodoro.Core/Interfaces/IServices/ISettingsService.cs
+++ b/Pomodoro.Core/Interfaces/IServices/ISettingsService.cs
@@ -1,0 +1,12 @@
+﻿using Pomodoro.Core.Models;
+
+namespace Pomodoro.Core.Interfaces.IServices
+{
+    public interface ISettingsService
+    {
+        Task<SettingsModel?> GetSettingsAsync(Guid id);
+        Task<SettingsModel?> GetUserSettingsAsync(Guid userId);
+        Task<SettingsModel> CreateSettingsAsync(SettingsModel settingsModel);
+        Task<SettingsModel> UpdateSettingsAsync(SettingsModel settingsModel);
+    }
+}

--- a/Pomodoro.Core/Models/Base/BaseModel.cs
+++ b/Pomodoro.Core/Models/Base/BaseModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Pomodoro.Core.Models
+﻿namespace Pomodoro.Core.Models.Base
 {
     public abstract class BaseModel
     {

--- a/Pomodoro.Core/Models/Base/BaseUserOrientedModel.cs
+++ b/Pomodoro.Core/Models/Base/BaseUserOrientedModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Pomodoro.Core.Models
+﻿namespace Pomodoro.Core.Models.Base
 {
     public abstract class BaseUserOrientedModel
     {

--- a/Pomodoro.Core/Models/BaseModel.cs
+++ b/Pomodoro.Core/Models/BaseModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Pomodoro.Core.Models
+{
+    public abstract class BaseModel
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/Pomodoro.Core/Models/SettingsModel.cs
+++ b/Pomodoro.Core/Models/SettingsModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Pomodoro.Core.Models
+﻿using Pomodoro.Core.Models.Base;
+
+namespace Pomodoro.Core.Models
 {
     public class SettingsModel : BaseModel
     {

--- a/Pomodoro.Core/Models/SettingsModel.cs
+++ b/Pomodoro.Core/Models/SettingsModel.cs
@@ -1,0 +1,12 @@
+﻿namespace Pomodoro.Core.Models
+{
+    public class SettingsModel : BaseModel
+    {
+        public Guid UserId { get; set; }
+        public byte PomodoroDuration { get; set; }
+        public byte ShortBreak { get; set; }
+        public byte LongBreak { get; set; }
+        public byte PomodorosBeforeLongBreak { get; set; }
+        public bool AutostartEnabled { get; set; }
+    }
+}

--- a/Pomodoro.Core/Models/Statistics/AnnualStatistics.cs
+++ b/Pomodoro.Core/Models/Statistics/AnnualStatistics.cs
@@ -1,4 +1,6 @@
-﻿namespace Pomodoro.Core.Models.Statistics
+﻿using Pomodoro.Core.Models.Base;
+
+namespace Pomodoro.Core.Models.Statistics
 {
     public class AnnualStatistics : BaseUserOrientedModel
     {

--- a/Pomodoro.Core/Models/Statistics/DailyStatistics.cs
+++ b/Pomodoro.Core/Models/Statistics/DailyStatistics.cs
@@ -1,4 +1,6 @@
-﻿namespace Pomodoro.Core.Models.Statistics
+﻿using Pomodoro.Core.Models.Base;
+
+namespace Pomodoro.Core.Models.Statistics
 {
     public class DailyStatistics : BaseUserOrientedModel
     {

--- a/Pomodoro.Core/Models/Statistics/MonthlyStatistics.cs
+++ b/Pomodoro.Core/Models/Statistics/MonthlyStatistics.cs
@@ -1,4 +1,5 @@
 ﻿using Pomodoro.Core.Enums;
+using Pomodoro.Core.Models.Base;
 
 namespace Pomodoro.Core.Models.Statistics
 {

--- a/Pomodoro.DataAccess/EF/AppDbContext.cs
+++ b/Pomodoro.DataAccess/EF/AppDbContext.cs
@@ -19,7 +19,10 @@ namespace Pomodoro.DataAccess.EF
         public DbSet<TaskEntity> Tasks => Set<TaskEntity>();
         public DbSet<AppUser> AppUsers => Set<AppUser>();
 
-        public AppDbContext(DbContextOptions options) : base(options) { }
+        public AppDbContext(DbContextOptions options) : base(options)
+        {
+            ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+        }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Pomodoro.DataAccess/EF/AppDbContext.cs
+++ b/Pomodoro.DataAccess/EF/AppDbContext.cs
@@ -21,7 +21,6 @@ namespace Pomodoro.DataAccess.EF
 
         public AppDbContext(DbContextOptions options) : base(options)
         {
-            ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Pomodoro.DataAccess/Repositories/Realizations/BaseRepository.cs
+++ b/Pomodoro.DataAccess/Repositories/Realizations/BaseRepository.cs
@@ -25,20 +25,18 @@ namespace Pomodoro.DataAccess.Repositories.Realizations
         }
 
         public async Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate)
-            => await context.Set<T>()
-            .Where(predicate)
-            .AsNoTracking()
-            .ToListAsync();
+            => await context.Set<T>().Where(predicate).ToListAsync();
 
         public async Task<IEnumerable<T>> GetAllAsync()
-            => await context.Set<T>()
-            .AsNoTracking()
-            .ToListAsync();
+            => await context.Set<T>().ToListAsync();
 
         public async Task<T?> GetByIdAsync(Guid id)
+            => await context.Set<T>().FindAsync(id);
+
+        public async Task<bool> HasByIdAsync(Guid id)
             => await context.Set<T>()
-            .AsNoTracking()
-            .SingleOrDefaultAsync(entity => entity.Id == id);
+            .Where(entity => entity.Id == id)
+            .AnyAsync();
 
         public void Remove(T entity)
         {

--- a/Pomodoro.DataAccess/Repositories/Realizations/BaseRepository.cs
+++ b/Pomodoro.DataAccess/Repositories/Realizations/BaseRepository.cs
@@ -25,13 +25,20 @@ namespace Pomodoro.DataAccess.Repositories.Realizations
         }
 
         public async Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate)
-            => await context.Set<T>().Where(predicate).ToListAsync();
+            => await context.Set<T>()
+            .Where(predicate)
+            .AsNoTracking()
+            .ToListAsync();
 
         public async Task<IEnumerable<T>> GetAllAsync()
-            => await context.Set<T>().ToListAsync();
+            => await context.Set<T>()
+            .AsNoTracking()
+            .ToListAsync();
 
         public async Task<T?> GetByIdAsync(Guid id)
-            => await context.Set<T>().FindAsync(id);
+            => await context.Set<T>()
+            .AsNoTracking()
+            .SingleOrDefaultAsync(entity => entity.Id == id);
 
         public void Remove(T entity)
         {

--- a/Pomodoro.Services/Class1.cs
+++ b/Pomodoro.Services/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace Pomodoro.Services
-{
-    public class Class1
-    {
-
-    }
-}

--- a/Pomodoro.Services/Mapping/SettingsProfile.cs
+++ b/Pomodoro.Services/Mapping/SettingsProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using Pomodoro.Core.Models;
+using Pomodoro.DataAccess.Entities;
+
+namespace Pomodoro.Services.Mapping
+{
+    public class SettingsProfile : Profile
+    {
+        public SettingsProfile()
+        {
+            CreateMap<Settings, SettingsModel>()
+                .ReverseMap();
+            //CreateMap<SettingsModel, Settings>()
+            //    .ForMember(dest => dest.User, opt => opt.Ignore());
+        }
+    }
+}

--- a/Pomodoro.Services/Pomodoro.Services.csproj
+++ b/Pomodoro.Services/Pomodoro.Services.csproj
@@ -6,4 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+  </ItemGroup>
 </Project>

--- a/Pomodoro.Services/Pomodoro.Services.csproj
+++ b/Pomodoro.Services/Pomodoro.Services.csproj
@@ -9,4 +9,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pomodoro.Core\Pomodoro.Core.csproj" />
+    <ProjectReference Include="..\Pomodoro.DataAccess\Pomodoro.DataAccess.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Pomodoro.Services/Realizations/SettingsService.cs
+++ b/Pomodoro.Services/Realizations/SettingsService.cs
@@ -28,6 +28,7 @@ namespace Pomodoro.Services.Realizations
 
             var settings = mapper.Map<Settings>(settingsModel);
 
+            await RemoveExistingSettings(settings.UserId);
             await settingsRepository.AddAsync(settings);
             await settingsRepository.SaveChangesAsync();
 
@@ -66,6 +67,18 @@ namespace Pomodoro.Services.Realizations
             await settingsRepository.SaveChangesAsync();
 
             return mapper.Map<SettingsModel>(settings);
+        }
+
+        private async Task RemoveExistingSettings(Guid userId)
+        {
+            var settings = await settingsRepository
+                .FindAsync(s => s.UserId == userId);
+
+            if (settings?.Count() > 0)
+            {
+                settingsRepository.RemoveRange(settings);
+                await settingsRepository.SaveChangesAsync();
+            }   
         }
     }
 }

--- a/Pomodoro.Services/Realizations/SettingsService.cs
+++ b/Pomodoro.Services/Realizations/SettingsService.cs
@@ -61,8 +61,8 @@ namespace Pomodoro.Services.Realizations
                 throw new ArgumentNullException(nameof(settingsModel));
             }
 
-            var settingsToUpdate = await settingsRepository.GetByIdAsync(settingsModel.Id);
-            if (settingsToUpdate is null)
+            if (!await settingsRepository
+                .HasByIdAsync(settingsModel.Id))
             {
                 return null;
             }

--- a/Pomodoro.Services/Realizations/SettingsService.cs
+++ b/Pomodoro.Services/Realizations/SettingsService.cs
@@ -1,0 +1,71 @@
+﻿using AutoMapper;
+using Pomodoro.Core.Interfaces.IServices;
+using Pomodoro.Core.Models;
+using Pomodoro.DataAccess.Entities;
+using Pomodoro.DataAccess.Repositories.Interfaces;
+
+namespace Pomodoro.Services.Realizations
+{
+    public class SettingsService : ISettingsService
+    {
+        private readonly IMapper mapper;
+        private readonly ISettingsRepository settingsRepository;
+
+        public SettingsService(
+            IMapper mapper,
+            ISettingsRepository settingsRepository)
+        {
+            this.mapper = mapper;
+            this.settingsRepository = settingsRepository;
+        }
+
+        public async Task<SettingsModel> CreateSettingsAsync(SettingsModel settingsModel)
+        {
+            if (settingsModel is null)
+            {
+                throw new ArgumentNullException(nameof(settingsModel));
+            }
+
+            var settings = mapper.Map<Settings>(settingsModel);
+
+            await settingsRepository.AddAsync(settings);
+            await settingsRepository.SaveChangesAsync();
+
+            return mapper.Map<SettingsModel>(settings);
+        }
+
+        public async Task<SettingsModel?> GetSettingsAsync(Guid id)
+        {
+            var settings = await settingsRepository.GetByIdAsync(id);
+            return mapper.Map<SettingsModel>(settings);
+        }
+
+        public async Task<SettingsModel?> GetUserSettingsAsync(Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new ArgumentException("Argument value is all zeroes.", nameof(userId));
+            }
+
+            var settings = await settingsRepository
+                .FindAsync(s => s.UserId == userId);
+            
+            return mapper.Map<SettingsModel>(settings?.FirstOrDefault());
+        }
+
+        public async Task<SettingsModel> UpdateSettingsAsync(SettingsModel settingsModel)
+        {
+            if (settingsModel is null)
+            {
+                throw new ArgumentNullException(nameof(settingsModel));
+            }
+
+            var settings = mapper.Map<Settings>(settingsModel);
+
+            settingsRepository.Update(settings);
+            await settingsRepository.SaveChangesAsync();
+
+            return mapper.Map<SettingsModel>(settings);
+        }
+    }
+}

--- a/Pomodoro.Services/Realizations/SettingsService.cs
+++ b/Pomodoro.Services/Realizations/SettingsService.cs
@@ -54,11 +54,17 @@ namespace Pomodoro.Services.Realizations
             return mapper.Map<SettingsModel>(settings?.FirstOrDefault());
         }
 
-        public async Task<SettingsModel> UpdateSettingsAsync(SettingsModel settingsModel)
+        public async Task<SettingsModel?> UpdateSettingsAsync(SettingsModel settingsModel)
         {
             if (settingsModel is null)
             {
                 throw new ArgumentNullException(nameof(settingsModel));
+            }
+
+            var settingsToUpdate = await settingsRepository.GetByIdAsync(settingsModel.Id);
+            if (settingsToUpdate is null)
+            {
+                return null;
             }
 
             var settings = mapper.Map<Settings>(settingsModel);


### PR DESCRIPTION
- Added settings models
- Added AutoMapper configs for these models
- Defined interface and its implementation for managing settings
- Created a controller for retrieving, creating, and updating settings
- Added a null check to the logic of the ValidateModel attribute, which is used globally and allows to avoid repeated checks of input models in the controller actions
- Configured swagger to take a JWT token and automatically add it to the authorization header. This provides a convenient way to test authorized endpoints.
- Set no-tracking behavior at the context level to avoid exceptions raised by EF Core while trying to update an entity.